### PR TITLE
背景图片部分的更改和修复

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -14,7 +14,6 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-attachment: fixed;
 }
 a {
   text-decoration: none;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,18 @@
     <link rel="icon" href="{{ env.page.favicon }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
     <style>
-        body {
-            background: url('{{ env.page.background }}') no-repeat center center fixed;
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: -1;
+            background: url('{{ env.page.background }}') no-repeat center center;
+            background-size: cover; 
+            will-change: transform; /* ai让我加上这两行 汗 */
+            transform: translateZ(0); /* Safari 强制开启 GPU 合成，防抖动 */
         }
     </style>
 


### PR DESCRIPTION
一些超级小的细节修改（
1.使用伪元素固定背景，防止在iOS/Safari上会错误滚动（根据TG @illlights (github @RichardTang2003 )用户的反馈指导修复），这貌似是一个iOS自己的bug，但是还好网页端能修复。
2.添加background-size: cover指定背景图片缩放，防止如[RLS的随机图片API](https://api.rls.ovh)、[Galgame 随机 CG 图 API](https://api.illlights.com/zh/v1/img)这些其他的图片API缩放错误（所以为什么竟然不是默认就有，把随机图片API塞进去时候都震惊了💔）