### PR TITLE
docs: 修复一些文档中过时的变量名

### DIFF
--- a/doc/deploy.md
+++ b/doc/deploy.md
@@ -13,9 +13,9 @@
     - [安装](#安装)
     - [启动](#启动)
   - [Huggingface 部署](#huggingface-部署)
-<<<<<<< HEAD
+  <<<<<<< HEAD
     - [我承认你的代码写的确实很nb，但对我来说还是太吃操作了 (已过时)](#我承认你的代码写的确实很nb但对我来说还是太吃操作了-已过时)
-=======
+  =======
 >>>>>>> main
     - [卡在 Deploying?](#卡在-deploying)
     - [如何使用自定义域名](#如何使用自定义域名)
@@ -69,8 +69,8 @@ uv sync
 ```ini
 sleepy_main_host = "0.0.0.0" # 监听地址
 sleepy_main_port = "9010" # 端口号
-sleepy_secret = "改成别人猜不出来的密钥" # 密钥，相当于密码
-sleepy_page_user = "你的名字" # 将显示在网页中
+sleepy_main_secret = "改成别人猜不出来的密钥" # 密钥，相当于密码
+sleepy_page_name = "你的名字" # 将显示在网页中
 sleepy_page_favicon = "./static/favicon.ico" # 网站图标, 可替换 static/favicon.ico 自定义 (也可以用其他格式的, 自己改路径)
 sleepy_page_more_text = "欢迎来到我的状态页!" # 说两句? (也可以留空)
 sleepy_page_using_first = true # 使用中设备优先显示

--- a/doc/env.md
+++ b/doc/env.md
@@ -18,40 +18,40 @@
 
 ## (main) 系统基本配置
 
-| 变量名                           | 类型 | 默认值          | 说明                                                                                                          |
-| -------------------------------- | ---- | --------------- | ------------------------------------------------------------------------------------------------------------- |
-| `sleepy_main_host`               | str  | `0.0.0.0`       | 服务的监听地址，如需同时监听 IPv6 地址需改为 `::`                                                             |
-| `sleepy_main_port`               | int  | 9010            | 服务的监听端口 *(0-65535)*                                                                                    |
-| `sleepy_main_debug`              | bool | false           | 控制是否开启 Flask 的调试模式 (一般无需开启) *(开启后可自动重载代码)*                                         |
+| 变量名                           | 类型 | 默认值          | 说明                                                         |
+| -------------------------------- | ---- | --------------- | ------------------------------------------------------------ |
+| `sleepy_main_host`               | str  | `0.0.0.0`       | 服务的监听地址，如需同时监听 IPv6 地址需改为 `::`            |
+| `sleepy_main_port`               | int  | 9010            | 服务的监听端口 *(0-65535)*                                   |
+| `sleepy_main_debug`              | bool | false           | 控制是否开启 Flask 的调试模式 (一般无需开启) *(开启后可自动重载代码)* |
 | `sleepy_main_timezone`           | str  | `Asia/Shanghai` | 控制 **API 返回中 / 网页上**显示时间的时区，一般无需更改 *(`Asia/Shanghai` 或 `Asia/Chongqing` 均为北京时间)* |
-| `sleepy_main_checkdata_interval` | int  | 30              | 控制多久检查一次状态数据的更新 **(秒)** (*检测到更新后会写入 `data.json`，供下次启动时恢复状态*)              |
-| `SLEEPY_SECRET`                  | str  | ` `             | 密钥 (相当于密码，用于防止未授权设置状态)，**客户端须使用相同的密钥**                                         |
-| `sleepy_main_https_enabled`      | bool | false           | 是否启用 HTTPS，启用后需配置 `sleepy_main_ssl_cert` 和 `sleepy_main_ssl_key`                                  |
-| `sleepy_main_ssl_cert`           | str  | `cert.pem`      | SSL 证书路径 (相对于项目根目录或绝对路径)，详见 [HTTPS 配置指南](./https.md)                                  |
-| `sleepy_main_ssl_key`            | str  | `key.pem`       | SSL 密钥路径 (相对于项目根目录或绝对路径)，详见 [HTTPS 配置指南](./https.md)                                  |
+| `sleepy_main_checkdata_interval` | int  | 30              | 控制多久检查一次状态数据的更新 **(秒)** (*检测到更新后会写入 `data.json`，供下次启动时恢复状态*) |
+| `sleepy_main_secret`             | str  | ` `             | 密钥 (相当于密码，用于防止未授权设置状态)，**客户端须使用相同的密钥** |
+| `sleepy_main_https_enabled`      | bool | false           | 是否启用 HTTPS，启用后需配置 `sleepy_main_ssl_cert` 和 `sleepy_main_ssl_key` |
+| `sleepy_main_ssl_cert`           | str  | `cert.pem`      | SSL 证书路径 (相对于项目根目录或绝对路径)，详见 [HTTPS 配置指南](./https.md) |
+| `sleepy_main_ssl_key`            | str  | `key.pem`       | SSL 密钥路径 (相对于项目根目录或绝对路径)，详见 [HTTPS 配置指南](./https.md) |
 
 ---
 
 ## (page) 页面内容配置
 
-| 变量名                    | 类型 | 默认值                            | 说明                                                                                                         |
-| ------------------------- | ---- | --------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `sleepy_page_user`        | str  | `User`                            | 网页顶部 `(用户名)'s Status` 中用户名                                                                        |
-| `sleepy_page_title`       | str  | `(用户名) Alive?`                 | 标题栏中显示的网页标题                                                                                       |
-| `sleepy_page_desc`        | str  | `(用户名)'s Online Status Page`   | 网页描述 *(主要用于 SEO)*                                                                                    |
-| `sleepy_page_favicon`     | str  | `./static/favicon.ico`            | 网页的图标 (`.png` 或 `.ico` 图片) 路径，可以为绝对路径或相对路径                                            |
-| `sleepy_page_background`  | str  | `https://imgapi.siiway.top/image` | 背景图片地址，可以使用网上的图片 API 或单张图片 *(默认为 [siiway/imgapi](https://github.com/siiway/imgapi))* |
-| `sleepy_page_learn_more`  | str  | `GitHub Repo`                     | 网页底部链接的**显示文字**                                                                                   |
-| `sleepy_page_repo`        | str  | `https://github.com/sleepy-project/sleepy`  | 网页底部链接的**目标** *(默认为本 repo 地址)*                                                                |
-| `sleepy_page_more_text`   | str  | ` `                               | 网页底部链接上方插入的文字 (**支持 HTML**，可以插入 统计代码 / 备案号 等)                                    |
-| `sleepy_page_sorted`      | bool | false                             | 是否按字母顺序排序设备列表                                                                                   |
-| `sleepy_page_using_first` | bool | false                             | 是否设置使用中设备优先显示                                                                                   |
-| `sleepy_page_hitokoto`    | bool | true                              | 在插入文字上方显示随机 [一言](https://hitokoto.cn)                                                           |
-| `sleepy_page_canvas`      | bool | true                              | 是否启用粒子效果 *(如影响性能可关闭)*                                                                        |
-| `sleepy_page_moonlight`   | bool | true                              | 在卡片左上角 / 右上角显示**切换暗色模式**和**卡片透明度**的按钮                                              |
-| `sleepy_page_lantern`     | bool | false                             | 在网页顶部显示节日灯笼 *(默认文字为 `欢度新春`)*                                                             |
-| `sleepy_page_mplayer`     | bool | false                             | 在网页左下角显示**音乐播放器**                                                                               |
-| `sleepy_page_zhixue`      | bool | false                             | 显示智学网分数 (详见 **[对应客户端设置](../client/README.md#zhixuewang)**)                                   |
+| 变量名                    | 类型 | 默认值                                     | 说明                                                         |
+| ------------------------- | ---- | ------------------------------------------ | ------------------------------------------------------------ |
+| `sleepy_page_name`        | str  | `User`                                     | 网页顶部 `(用户名)'s Status` 中用户名                        |
+| `sleepy_page_title`       | str  | `(用户名) Alive?`                          | 标题栏中显示的网页标题                                       |
+| `sleepy_page_desc`        | str  | `(用户名)'s Online Status Page`            | 网页描述 *(主要用于 SEO)*                                    |
+| `sleepy_page_favicon`     | str  | `./static/favicon.ico`                     | 网页的图标 (`.png` 或 `.ico` 图片) 路径，可以为绝对路径或相对路径 |
+| `sleepy_page_background`  | str  | `https://imgapi.siiway.top/image`          | 背景图片地址，可以使用网上的图片 API 或单张图片 *(默认为 [siiway/imgapi](https://github.com/siiway/imgapi))* |
+| `sleepy_page_learn_more`  | str  | `GitHub Repo`                              | 网页底部链接的**显示文字**                                   |
+| `sleepy_page_repo`        | str  | `https://github.com/sleepy-project/sleepy` | 网页底部链接的**目标** *(默认为本 repo 地址)*                |
+| `sleepy_page_more_text`   | str  | ` `                                        | 网页底部链接上方插入的文字 (**支持 HTML**，可以插入 统计代码 / 备案号 等) |
+| `sleepy_page_sorted`      | bool | false                                      | 是否按字母顺序排序设备列表                                   |
+| `sleepy_page_using_first` | bool | false                                      | 是否设置使用中设备优先显示                                   |
+| `sleepy_page_hitokoto`    | bool | true                                       | 在插入文字上方显示随机 [一言](https://hitokoto.cn)           |
+| `sleepy_page_canvas`      | bool | true                                       | 是否启用粒子效果 *(如影响性能可关闭)*                        |
+| `sleepy_page_moonlight`   | bool | true                                       | 在卡片左上角 / 右上角显示**切换暗色模式**和**卡片透明度**的按钮 |
+| `sleepy_page_lantern`     | bool | false                                      | 在网页顶部显示节日灯笼 *(默认文字为 `欢度新春`)*             |
+| `sleepy_page_mplayer`     | bool | false                                      | 在网页左下角显示**音乐播放器**                               |
+| `sleepy_page_zhixue`      | bool | false                                      | 显示智学网分数 (详见 **[对应客户端设置](../client/README.md#zhixuewang)**) |
 
 ## (status) 页面状态显示配置
 


### PR DESCRIPTION
有一段时间没有更新过sleepy，结果一pull发现之前的配置都不能用了，看文档感觉没问题，后来翻了源代码才发现好多变量名做了更改没有同步到文档，我修改了几个我找到的不同，其他如果还有变量名做了修改也希望能同步更新下文档，不然配置了半天不生效（）