### PR TITLE
Fastapi-dev static file and theme file api implement

### DIFF
--- a/config_models.py
+++ b/config_models.py
@@ -67,6 +67,8 @@ class ConfigModel(BaseModel):
     Event-Stream Ping 间隔 (单位: 秒, 设置为 0 禁用)
     '''
 
+    default_theme: str = 'default'
+
 # endregion user-config
 
 

--- a/main.py
+++ b/main.py
@@ -348,8 +348,7 @@ async def redirect_api(request: Request, call_next):
     from models import redirect_map
     if request.url.path in redirect_map:
         new_path = redirect_map.get(request.url.path, '/')
-        query = request.url.query
-        if query:
+        if query := request.url.query:
             redirect_path = f'{new_path}?{query}'
         else:
             redirect_path = new_path

--- a/main.py
+++ b/main.py
@@ -277,21 +277,20 @@ def static_themed(theme: str, filename: str):
     '''
     经过主题分隔的静态文件 (便于 cdn / 浏览器 进行缓存)
     '''
-    try:
-        # 1. 返回主题
-        resp = FileResponse(safe_join('theme', f'{theme}/static/{filename}'))
+    filepath = safe_join('theme', f'{theme}/static/{filename}')
+    # 1. 返回主题
+    if u.is_file_exist(filepath):
+        resp = FileResponse(filepath)
         l.debug(f'[theme] return static file {filename} from theme {theme}')
         return resp
-    except FileNotFoundError:
-        # 2. 主题不存在 (而且不是默认) -> fallback 到默认
-        if theme != 'default':
-            l.debug(f'[theme] static file {filename} not found in theme {theme}, fallback to default')
-            return u.no_cache_response(RedirectResponse(f'/static-themed/default/{filename}', 302))
-
-        # 3. 默认主题也没有 -> 404
-        else:
-            l.warning(f'[theme] static file {filename} not found')
-            raise u.no_cache_response(HTTPException(status_code=404, detail=f'Static file {filename} in theme {theme} not found'))
+    # 2. 主题不存在 (而且不是默认) -> fallback 到默认
+    elif theme != 'default':
+        l.debug(f'[theme] static file {filename} not found in theme {theme}, fallback to default')
+        return u.no_cache_response(RedirectResponse(f'/static-themed/default/{filename}', 302))
+    # 3. 默认主题也没有 -> 404
+    else:
+        l.warning(f'[theme] static file {filename} not found')
+        raise u.no_cache_response(HTTPException(status_code=404, detail=f'Static file {filename} in theme {theme} not found'))
 
 
 @app.get('/default/{filename:path}')

--- a/main.py
+++ b/main.py
@@ -357,8 +357,7 @@ async def redirect_api(request: Request, call_next):
 
     if request.query_params.get('theme'):
         theme = request.query_params.get('theme')
-        url=request.url
-        url.remove_query_params('theme')
+        url=request.url.remove_query_params('theme')
         l.debug(f'Redirecting to new url: {url}')
         resp = RedirectResponse(str(url), status_code=302)
         resp.set_cookie('sleepy-theme', theme, samesite='lax')

--- a/models.py
+++ b/models.py
@@ -37,3 +37,18 @@ class DeviceData(SQLModel, table=True):
     using: bool = Field(default=True)
     fields: t.Dict[str, t.Any] = Field(default={}, sa_type=JSON)
     last_updated: float = Field(default=time())
+
+
+redirect_map = {
+    '/query': '/api/status/query',
+    '/status_list': '/api/status/list',
+    '/metrics': '/api/metrics',
+    '/set': '/api/status/set',
+    '/device/set': '/api/device/set',
+    '/device/remove': '/api/device/remove',
+    '/device/clear': '/api/device/clear',
+    '/device/private_mode': '/api/device/private',
+    '/metadata': '/api/meta',
+    '/verify-secret': '/panel/verify',
+    '/events': '/api/status/events'
+}

--- a/utils.py
+++ b/utils.py
@@ -59,6 +59,35 @@ class CustomFormatter(Formatter):
         return formatted_message
 
 
+def cache_response(resp):
+    '''
+    给返回添加缓存标头
+    '''
+    resp.headers['Cache-Control'] = 'max-age=86400, must-revalidate'
+    resp.headers['Expires'] = '86400'
+    return resp
+
+
+def no_cache_response(resp):
+    '''
+    给返回添加阻止缓存标头
+    '''
+    resp.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+    resp.headers['Pragma'] = 'no-cache'
+    resp.headers['Expires'] = '0'
+    return resp
+
+
+
+def is_file_exist(path: str) -> bool:
+    '''
+    检查文件是否存在
+
+    :param path: 文件路径
+    :return: 是否存在
+    '''
+    return Path(path).exists()
+
 def current_dir() -> str:
     '''
     获取当前主程序所在目录


### PR DESCRIPTION
正在尝试协助实现Fastapi下的sleepy
写完再转正式PR。先占个坑+等待大大们意见。
尝试复用、移植了一些旧版中能用的函数。
但有关_themes_available_cache，get_cached_file等多个文件中有关cache的对象与函数，不知是否应该继续使用，还是应该移除。
还望大大们提一些意见与方向。

## Sourcery 总结

将主题支持和旧路径重定向集成到 FastAPI 应用中，其中包含模板渲染、静态文件路由、中间件和实用工具函数。

新功能：
- 实现主题渲染，包括 `render_template`、主题化静态端点和默认静态路由

增强功能：
- 添加 HTTP 中间件，用于从 cookies 或查询参数设置主题
- 引入使用 models 中 `redirect_map` 的 API 重定向中间件
- 添加 `cache_response`、`no_cache_response` 和 `is_file_exist` 实用工具函数
- 将 `default_theme` 设置添加到配置模型中

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在 FastAPI 中实现基于主题的模板和静态文件服务，带有用于主题选择和旧版路由重定向的中间件，并添加用于缓存和文件存在性检查的实用函数。

新功能：
- 添加主题感知的模板渲染，并支持回退到默认主题
- 通过主题路由（/static、/static-themed 和 /default）提供静态资源
- 注入 HTTP 中间件，通过 cookie 或查询参数选择主题
- 根据 redirect_map 实现旧版端点重定向，以实现向后兼容性

改进：
- 引入 `cache_response` 和 `no_cache_response` 实用工具来管理缓存头
- 添加 `is_file_exist` 辅助函数以验证文件是否存在
- 在配置模型中添加 `default_theme` 选项

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement theme-based template and static file serving in FastAPI with middleware for theme selection and legacy route redirects, and add utility functions for caching and file existence checks

New Features:
- Add theme-aware template rendering with fallback to default theme
- Serve static assets through themed routes (/static, /static-themed, and /default)
- Inject HTTP middleware for selecting themes via cookies or query parameters
- Implement legacy endpoint redirects based on redirect_map for backward compatibility

Enhancements:
- Introduce cache_response and no_cache_response utilities to manage cache headers
- Add is_file_exist helper to verify file presence
- Add default_theme option to configuration model

</details>

</details>